### PR TITLE
Add nix garbage collection daemon to default config

### DIFF
--- a/darwin-configuration.nix
+++ b/darwin-configuration.nix
@@ -79,5 +79,10 @@
     "nixpkgs=$HOME/.nix-defexpr/channels/nixpkgs" # NixOS/nix#1865
   ];
 
+  nix.gc = {
+    automatic = true;
+    options = "--delete-older-than 30d";
+  };
+
   nixpkgs.config = import ./config.nix;
 }


### PR DESCRIPTION
So as not to foot-gun users with ever-growing nix-stores